### PR TITLE
fix two links

### DIFF
--- a/LinearAlgebraInOSCAR.ipynb
+++ b/LinearAlgebraInOSCAR.ipynb
@@ -57,7 +57,7 @@
    "id": "49ec5cc7-e1fb-4b90-a9c0-1f791cd63a92",
    "metadata": {},
    "source": [
-    "*OSCAR* has its own type of matrix, independent of Julia's in-built matrices. This is due to technical limitations in Julia. Specifically, every matrix in *OSCAR* has a unique coefficient ring assigned to it. For a Julia matrix, this is not possible. Also, types (even with parameters) are not suitable for this purpose. For details, see https://docs.oscar-system.org/stable/AbstractAlgebra/matrix_algebras/#Basic-matrix-functionality. For conversion of the \"normal\" julia matrices into *OSCAR* matrices, see for instance https://docs.oscar-system.org/stable/AbstractAlgebra/matrix/#Conversion-to-Julia-matrices,-iteration-and-broacasting.\n",
+    "*OSCAR* has its own type of matrix, independent of Julia's in-built matrices. This is due to technical limitations in Julia. Specifically, every matrix in *OSCAR* has a unique coefficient ring assigned to it. For a Julia matrix, this is not possible. Also, types (even with parameters) are not suitable for this purpose. For details, see https://docs.oscar-system.org/stable/AbstractAlgebra/matrix/#Basic-matrix-functionality. For conversion of the \"normal\" julia matrices into *OSCAR* matrices, see for instance https://docs.oscar-system.org/stable/AbstractAlgebra/matrix/#Conversion-to-Julia-matrices,-iteration-and-broacasting.\n",
     "\n",
     "*Oscar* matrices are typically created with the (*Oscar*) function `matrix` with a small \"m\"; whereas Julia's built-in matrices have types written `Matrix{...}` with a big \"M\". In conclusion, use `matrix` with small \"m\" within *OSCAR*.\n",
     "\n",
@@ -1531,7 +1531,7 @@
    "id": "83dcc841-8d75-48e0-8d5f-0a0e9de0c679",
    "metadata": {},
    "source": [
-    "Fix non-negative integers $r$, $c$ and a ring $R$. The set of all $r \\times c$ matrices defined over the coefficient ring $R$ is called a matrix space. *OSCAR* provides functionality for these spaces. For details, the interested reader may for instance wish to consult https://docs.oscar-system.org/stable/AbstractAlgebra/matrix/#Matrix-functionality.\n",
+    "Fix non-negative integers $r$, $c$ and a ring $R$. The set of all $r \\times c$ matrices defined over the coefficient ring $R$ is called a matrix space. *OSCAR* provides functionality for these spaces. For details, the interested reader may for instance wish to consult https://docs.oscar-system.org/stable/AbstractAlgebra/matrix_spaces/#Basic-matrix-space-functionality.\n",
     "\n",
     "Let us give an example for how to obtain the matrix space of a matrix:"
    ]


### PR DESCRIPTION
- Information why Oscar needs its own matrix types can be found at https://docs.oscar-system.org/stable/AbstractAlgebra/matrix/#Basic-matrix-functionality not at https://docs.oscar-system.org/stable/AbstractAlgebra/matrix_algebras/#Basic-matrix-functionality.
- Information about matrix spaces can be found at https://docs.oscar-system.org/stable/AbstractAlgebra/matrix_spaces/#Basic-matrix-space-functionality not at https://docs.oscar-system.org/stable/AbstractAlgebra/matrix/#Matrix-functionality.