### PR TITLE
Remove inttype

### DIFF
--- a/pi_piprime_generation.ipynb
+++ b/pi_piprime_generation.ipynb
@@ -227,7 +227,7 @@
    "source": [
     "filename = string(GAP.Globals.Filename(GAP.Globals.DirectoriesPackageLibrary(GAP.Obj(\"ctbllib\"),GAP.Obj(\"data\")), GAP.Obj(\"prim_perm_M.json\")));\n",
     "str = read(filename, String);\n",
-    "monster_prim_data = Oscar.JSON.parse(str; inttype = BigInt)[2];\n",
+    "monster_prim_data = Oscar.JSON.parse(str)[2];\n",
     "length(monster_prim_data)"
    ]
   },


### PR DESCRIPTION
This should've been caught when we migrated from JSON3 to JSON, but the tutorial tester was unfortunately still testing against an older version of OSCAR.